### PR TITLE
ConnectionManager::get_connection may return dangling reference causing data races

### DIFF
--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -19,11 +19,6 @@ std::optional<ConnectionInfo> ConnectionManager::get_connection(int socket_fd) c
     return std::nullopt;
 }
 
-void ConnectionManager::set_connection(int socket_fd, const ConnectionInfo& info) {
-    std::lock_guard<std::mutex> lock(mtx);
-    connections[socket_fd] = info;
-}
-
 std::string ConnectionManager::get_session_key_by_customer_id(const std::string& customer_id) const {
     std::lock_guard<std::mutex> lock(mtx);
     for (const auto& [fd, info] : connections) {

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -19,13 +19,9 @@ std::optional<ConnectionInfo> ConnectionManager::get_connection(int socket_fd) c
     return std::nullopt;
 }
 
-std::optional<std::reference_wrapper<ConnectionInfo>> ConnectionManager::get_connection(int socket_fd) {
+void ConnectionManager::set_connection(int socket_fd, const ConnectionInfo& info) {
     std::lock_guard<std::mutex> lock(mtx);
-    auto it = connections.find(socket_fd);
-    if (it != connections.end()) {
-        return it->second;
-    }
-    return std::nullopt;
+    connections[socket_fd] = info;
 }
 
 std::string ConnectionManager::get_session_key_by_customer_id(const std::string& customer_id) const {

--- a/src/connection_manager.hpp
+++ b/src/connection_manager.hpp
@@ -20,8 +20,15 @@ public:
     std::string get_session_key_by_customer_id(const std::string& customer_id) const;
     void clear(); // For testability
 
-    // Set or update a connection's info by socket_fd
-    void set_connection(int socket_fd, const ConnectionInfo& info);
+    // Thread-safe in-place update method for a connection
+    template<typename Func>
+    void update_connection(int socket_fd, Func mutator) {
+        std::lock_guard<std::mutex> lock(mtx);
+        auto it = connections.find(socket_fd);
+        if (it != connections.end()) {
+            mutator(it->second);
+        }
+    }
 
 private:
     mutable std::mutex mtx;

--- a/src/connection_manager.hpp
+++ b/src/connection_manager.hpp
@@ -20,8 +20,8 @@ public:
     std::string get_session_key_by_customer_id(const std::string& customer_id) const;
     void clear(); // For testability
 
-    // Add a mutable overload for get_connection
-    std::optional<std::reference_wrapper<ConnectionInfo>> get_connection(int socket_fd);
+    // Set or update a connection's info by socket_fd
+    void set_connection(int socket_fd, const ConnectionInfo& info);
 
 private:
     mutable std::mutex mtx;

--- a/src/custom1_decrypt_fixture.cpp
+++ b/src/custom1_decrypt_fixture.cpp
@@ -9,8 +9,8 @@
 // Helper: hex string to binary
 std::vector<unsigned char> hex_to_bin(const std::string& hex) {
     std::vector<unsigned char> out;
-    for (size_t i = 0; i < hex.size(); i += 2) {
-        unsigned char byte = (unsigned char)((std::stoi(hex.substr(i, 1), nullptr, 16) << 4) | std::stoi(hex.substr(i + 1, 1), nullptr, 16));
+    for (size_t i = 0; i + 1 < hex.size(); i += 2) {
+        unsigned char byte = (unsigned char)std::stoi(hex.substr(i, 2), nullptr, 16);
         out.push_back(byte);
     }
     return out;

--- a/src/custom1_handlers.cpp
+++ b/src/custom1_handlers.cpp
@@ -143,11 +143,11 @@ void handle_custom1_login(const Custom1Packet &pkt, int connection_id, const std
             ConnectionManager &conn_mgr = custom1_conn_mgr;
             auto conn_info_opt = conn_mgr.get_connection(connection_id);
             if (conn_info_opt) {
-                ConnectionInfo conn_info = *conn_info_opt;
-                conn_info.session_key = session_key_hex;
-                conn_info.customer_id = *customer_id_opt;
-                conn_mgr.set_connection(connection_id, conn_info);
-                LOG("Session key stored for customer ID: " + conn_info.customer_id);
+                conn_mgr.update_connection(connection_id, [&](ConnectionInfo& conn_info) {
+                    conn_info.session_key = session_key_hex;
+                    conn_info.customer_id = *customer_id_opt;
+                    LOG("Session key stored for customer ID: " + conn_info.customer_id);
+                });
             }
         } else {
             LOG_ERROR("Decrypted buffer too short or invalid session key length: " + std::to_string(session_key_len));

--- a/src/custom1_handlers.cpp
+++ b/src/custom1_handlers.cpp
@@ -143,9 +143,10 @@ void handle_custom1_login(const Custom1Packet &pkt, int connection_id, const std
             ConnectionManager &conn_mgr = custom1_conn_mgr;
             auto conn_info_opt = conn_mgr.get_connection(connection_id);
             if (conn_info_opt) {
-                ConnectionInfo &conn_info = conn_info_opt->get();
+                ConnectionInfo conn_info = *conn_info_opt;
                 conn_info.session_key = session_key_hex;
                 conn_info.customer_id = *customer_id_opt;
+                conn_mgr.set_connection(connection_id, conn_info);
                 LOG("Session key stored for customer ID: " + conn_info.customer_id);
             }
         } else {

--- a/tests/test_connection_manager.cpp
+++ b/tests/test_connection_manager.cpp
@@ -24,10 +24,10 @@ TEST(ConnectionManagerTest, GetSessionKeyByCustomerId) {
     mgr.add_connection(5);
     auto conn = mgr.get_connection(5);
     ASSERT_TRUE(conn.has_value());
-    ConnectionInfo updated = *conn;
-    updated.session_key = "abc";
-    updated.customer_id = "xyz";
-    mgr.set_connection(5, updated);
+    mgr.update_connection(5, [](ConnectionInfo& c) {
+        c.session_key = "abc";
+        c.customer_id = "xyz";
+    });
     EXPECT_EQ(mgr.get_session_key_by_customer_id("xyz"), "abc");
 }
 

--- a/tests/test_connection_manager.cpp
+++ b/tests/test_connection_manager.cpp
@@ -6,9 +6,9 @@ TEST(ConnectionManagerTest, AddAndGetConnection) {
     mgr.add_connection(42);
     auto conn = mgr.get_connection(42);
     ASSERT_TRUE(conn.has_value());
-    EXPECT_EQ(conn->get().socket_fd, 42);
-    EXPECT_EQ(conn->get().session_key, "");
-    EXPECT_EQ(conn->get().customer_id, "");
+    EXPECT_EQ(conn->socket_fd, 42);
+    EXPECT_EQ(conn->session_key, "");
+    EXPECT_EQ(conn->customer_id, "");
 }
 
 TEST(ConnectionManagerTest, RemoveConnection) {
@@ -24,8 +24,10 @@ TEST(ConnectionManagerTest, GetSessionKeyByCustomerId) {
     mgr.add_connection(5);
     auto conn = mgr.get_connection(5);
     ASSERT_TRUE(conn.has_value());
-    conn->get().session_key = "abc";
-    conn->get().customer_id = "xyz";
+    ConnectionInfo updated = *conn;
+    updated.session_key = "abc";
+    updated.customer_id = "xyz";
+    mgr.set_connection(5, updated);
     EXPECT_EQ(mgr.get_session_key_by_customer_id("xyz"), "abc");
 }
 

--- a/tests/test_custom1_login.cpp
+++ b/tests/test_custom1_login.cpp
@@ -43,6 +43,6 @@ TEST(Custom1LoginTest, DecryptsAndStoresSessionKey) {
     // Assert: session key and customer_id are stored in the connection info
     auto conn_info_opt = custom1_conn_mgr.get_connection(connection_id);
     ASSERT_TRUE(conn_info_opt.has_value());
-    EXPECT_EQ(conn_info_opt->get().session_key, expected_session_key);
-    EXPECT_EQ(conn_info_opt->get().customer_id, customer_id);
+    EXPECT_EQ(conn_info_opt->session_key, expected_session_key);
+    EXPECT_EQ(conn_info_opt->customer_id, customer_id);
 }

--- a/tests/test_custom1_packet.cpp
+++ b/tests/test_custom1_packet.cpp
@@ -62,7 +62,7 @@ TEST(Custom1PacketTest, HandleCustom1PacketLogin) {
     EXPECT_TRUE(result);
     auto conn_info_opt = custom1_conn_mgr.get_connection(connection_id);
     ASSERT_TRUE(conn_info_opt.has_value());
-    EXPECT_EQ(conn_info_opt->get().session_key, expected_session_key);
-    EXPECT_EQ(conn_info_opt->get().customer_id, customer_id);
+    EXPECT_EQ(conn_info_opt->session_key, expected_session_key);
+    EXPECT_EQ(conn_info_opt->customer_id, customer_id);
     close(sv[0]); close(sv[1]);
 }


### PR DESCRIPTION
Fixes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved connection management by introducing a thread-safe update method for modifying connection details.
  - Enhanced hex string parsing to prevent errors during data conversion.
- **Tests**
  - Simplified and clarified test assertions to reflect the updated connection information handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->