### PR TITLE
Tighten check_password() helper: drop legacy crypt() fallback

### DIFF
--- a/src/login.cpp
+++ b/src/login.cpp
@@ -43,14 +43,14 @@ static bool is_bcrypt_hash(const std::string &hash)
 
 bool check_password(const std::string &password, const std::string &hash)
 {
+    // Only bcrypt hashes are supported (prefix $2, $2a, $2b, $2y)
+    // Legacy crypt() fallback is no longer supported.
     if (is_bcrypt_hash(hash)) {
         // Use libbcrypt for bcrypt hashes
         return bcrypt_checkpw(password.c_str(), hash.c_str()) == 0;
-    } else {
-        // Fallback to legacy crypt
-        char *result = crypt(password.c_str(), hash.c_str());
-        return result && strcmp(result, hash.c_str()) == 0;
     }
+    // Not a valid bcrypt hash; always fail
+    return false;
 }
 
 // Helper for parameter validation

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -46,8 +46,11 @@ bool check_password(const std::string &password, const std::string &hash)
     // Only bcrypt hashes are supported (prefix $2, $2a, $2b, $2y)
     // Legacy crypt() fallback is no longer supported.
     if (is_bcrypt_hash(hash)) {
-        // Use libbcrypt for bcrypt hashes
-        return bcrypt_checkpw(password.c_str(), hash.c_str()) == 0;
+        int rc = bcrypt_checkpw(password.c_str(), hash.c_str());
+        if (rc == -1) {
+            LOG_ERROR("bcrypt_checkpw() failed – possibly malformed hash");
+        }
+        return rc == 0;
     }
     // Not a valid bcrypt hash; always fail
     return false;


### PR DESCRIPTION
Fixes #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved password verification by supporting only bcrypt hashes, removing legacy password fallback.

- **Documentation**
	- Updated comments to clarify that only bcrypt password hashes are now supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->